### PR TITLE
Unused geometry IDs are not returned

### DIFF
--- a/examples/demo.py
+++ b/examples/demo.py
@@ -66,8 +66,8 @@ if __name__ == '__main__':
     print('Intersection between rays and scene - %.5fs' % (time.time() - t0))
 
     # Filter out rays without intersections.
-    geom_ids, tri_ids, bcoords, valid = rbutils.filter_intersections(geom_ids, bcoords)
-    print('Percentage of valid rays - %.2f%%' % (geom_ids.shape[0] / ray_origins.shape[0] * 100))
+    tri_ids, bcoords, valid = rbutils.filter_intersections(geom_ids, bcoords)
+    print('Percentage of valid rays - %.2f%%' % (tri_ids.shape[0] / ray_origins.shape[0] * 100))
 
     # Use barycentric interpolator to recover depth and RGB.
     t0 = time.time()

--- a/raybender/utils.py
+++ b/raybender/utils.py
@@ -1,6 +1,6 @@
-def compute_rays_for_simple_pinhole_camera(R, tvec, intrinsics):
-    import numpy as np
+import numpy as np
 
+def compute_rays_for_simple_pinhole_camera(R, tvec, intrinsics):
     # Recover intrinsics.
     w, h, f, cx, cy = intrinsics
 
@@ -27,25 +27,18 @@ def compute_rays_for_simple_pinhole_camera(R, tvec, intrinsics):
 
 
 def filter_intersections(geom_ids, bcoords):
-    import numpy as np
-
     # Geometry id is -1 if ray doesn't interesect any mesh.
     valid = (geom_ids[:, 0] != -1)
-    gids = geom_ids[:, 0][valid]
     tids = geom_ids[:, 1][valid]
     bcoords = bcoords[valid]
-    
+
     # Outputs must be contiguous.
-    gids = np.ascontiguousarray(gids)
     tids = np.ascontiguousarray(tids)
     bcoords = np.ascontiguousarray(bcoords)
-
-    return gids, tids, bcoords, valid
+    return tids, bcoords, valid
 
 
 def interpolate_rgbd_from_geometry(triangles, vertices, vertex_colors, tri_ids, bcoords, valid, R, tvec, w, h):
-    import numpy as np
-
     from ._raybender import barycentric_interpolator
 
     # Number of rays.


### PR DESCRIPTION
Since we always deal with a single mesh, we never really need to know the geometry ID. This spares some computations.