### PR TITLE
Use compact flag for scene to reduce memory usage

### DIFF
--- a/lib/scene.cc
+++ b/lib/scene.cc
@@ -5,7 +5,7 @@ void* create_scene(std::string config) {
     RTCScene scene = rtcNewScene(device);
     // Avoid optimizations that lower the arithmetic accuracy.
     // Solves most problems with rays passing through edges / vertices.
-    rtcSetSceneFlags(scene, RTC_SCENE_FLAG_ROBUST);
+    rtcSetSceneFlags(scene, RTC_SCENE_FLAG_COMPACT | RTC_SCENE_FLAG_ROBUST);
     return (void*)scene;
 }
 

--- a/lib/scene.cc
+++ b/lib/scene.cc
@@ -3,8 +3,11 @@
 void* create_scene(std::string config) {
     RTCDevice device = rtcNewDevice(config.c_str());
     RTCScene scene = rtcNewScene(device);
-    // Avoid optimizations that lower the arithmetic accuracy.
-    // Solves most problems with rays passing through edges / vertices.
+    // RTC_SCENE_FLAG_COMPACT uses less RAM by avoiding algos consuming much
+    // memory and changing the acceleration structures to more compact ones.
+    // RTC_SCENE_FLAG_ROBUST avoids optimizations that lower the arithmetic
+    // accuracy - this solves most problems with rays passing through edges or
+    // vertices.
     rtcSetSceneFlags(scene, RTC_SCENE_FLAG_COMPACT | RTC_SCENE_FLAG_ROBUST);
     return (void*)scene;
 }


### PR DESCRIPTION
From docs: `RTC_SCENE_FLAG_COMPACT: Uses compact acceleration structures and avoids algorithms that consume much memory.`

This makes LaMAR re-rendering (for released scenes) fit on a <64GB RAM machine :)
